### PR TITLE
Use new asm macro syntax

### DIFF
--- a/src/mips.rs
+++ b/src/mips.rs
@@ -2,42 +2,40 @@ pub const DCACHE_LINE_SIZE: usize = 16;
 pub const DCACHE_LINE_MASK: usize = !(DCACHE_LINE_SIZE - 1);
 
 pub unsafe fn write_cp0_count(new_count: u32) {
-    asm!("mtc0 $0, $$9"
-        :
-        : "r"(new_count));
+    asm!("mtc0 {}, $9",
+        in(reg) new_count);
 }
 
 pub unsafe fn read_cp0_count() -> u32 {
     let cp0_count: u32;
-    asm!("mfc0 $0, $$9"
-        : "=r"(cp0_count));
+    asm!("mfc0 $2, $9",
+        out("$2") cp0_count);
     cp0_count
 }
 
 pub unsafe fn write_cp0_compare(new_compare: u32) {
-    asm!("mtc0 $0, $$11"
-        :
-        : "r"(new_compare));
+    asm!("mtc0 {}, $11",
+        in(reg) new_compare);
 }
 
 pub unsafe fn read_cp0_compare() -> u32 {
     let cp0_compare: u32;
-    asm!("mfc0 $0, $$11"
-        : "=r"(cp0_compare));
+    asm!("mfc0 $2, $11",
+        out("$2") cp0_compare);
     cp0_compare
 }
 
 pub unsafe fn read_cp0_status() -> u32 {
     let cp0_status: u32;
-    asm!("mfc0 $0, $$12"
-        : "=r"(cp0_status));
+    asm!("mfc0 $2, $12",
+        out("$2") cp0_status);
     cp0_status
 }
 
 pub unsafe fn read_cp0_cause() -> u32 {
     let cp0_cause: u32;
-    asm!("mfc0 $0, $$13"
-        : "=r"(cp0_cause));
+    asm!("mfc0 $2, $13",
+        out("$2") cp0_cause);
     cp0_cause
 }
 
@@ -51,9 +49,8 @@ pub fn dcache_hit_writeback_invalidate(addr: usize, length: usize) {
     let mut current_base = aligned_base;
     while current_base < end {
         unsafe {
-            asm!("cache 0x15,($0)"
-                :
-                :"r"(current_base));
+            asm!("cache 0x15,($2)",
+                in("$2") current_base);
         }
         current_base += DCACHE_LINE_SIZE;
     }


### PR DESCRIPTION
In June 2020 Rust introduced [a new asm macro syntax](https://blog.rust-lang.org/inside-rust/2020/06/08/new-inline-asm.html), deprecating the old macro (and renaming it to `llvm_asm`). This PR converts the asm macros to the new format.

Side-by-side comparison using a debug build on the mips-unknown-linux-gnu target shows that this should still produce byte-for-byte exact output as before.